### PR TITLE
Remove is-plain-object dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,17 +18,13 @@ function isValidExtensions(extensions) {
 }
 
 function isValidRewritePaths(rewritePaths) {
-	return isPlainObject(rewritePaths) &&
-		Object.entries(rewritePaths).every(([from, to]) => {
-			return from.endsWith('/') && typeof to === 'string' && to.endsWith('/');
-		});
-}
+	if (!isPlainObject(rewritePaths)) {
+		return false;
+	}
 
-function isValidConfig(config) {
-	return isPlainObject(config) &&
-		Object.keys(config).every(key => key === 'extensions' || key === 'rewritePaths') &&
-		(config.extensions === undefined || isValidExtensions(config.extensions)) &&
-		isValidRewritePaths(config.rewritePaths);
+	return Object.entries(rewritePaths).every(([from, to]) => {
+		return from.endsWith('/') && typeof to === 'string' && to.endsWith('/');
+	});
 }
 
 module.exports = ({negotiateProtocol}) => {
@@ -39,7 +35,17 @@ module.exports = ({negotiateProtocol}) => {
 
 	return {
 		main({config}) {
-			if (!isValidConfig(config)) {
+			let valid = false;
+			if (isPlainObject(config)) {
+				const keys = Object.keys(config);
+				if (keys.every(key => key === 'extensions' || key === 'rewritePaths')) {
+					valid =
+						(config.extensions === undefined || isValidExtensions(config.extensions)) &&
+						isValidRewritePaths(config.rewritePaths);
+				}
+			}
+
+			if (!valid) {
 				throw new Error(`Unexpected Typescript configuration for AVA. See https://github.com/avajs/typescript/blob/v${pkg.version}/README.md for allowed values.`);
 			}
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ const escapeStringRegexp = require('escape-string-regexp');
 const pkg = require('./package.json');
 
 function isPlainObject(x) {
-	return x !== null && typeof x === 'object' &&
-		Reflect.getPrototypeOf(x) === Object.prototype;
+	return x !== null && typeof x === 'object' && Reflect.getPrototypeOf(x) === Object.prototype;
 }
 
 function isValidExtensions(extensions) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "test": "xo && nyc ava"
   },
   "dependencies": {
-    "escape-string-regexp": "^2.0.0",
-    "is-plain-object": "^3.0.0"
+    "escape-string-regexp": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^3.0.0",


### PR DESCRIPTION
Hi!

This PR removes `is-plain-object` dependency and so its indirect dependency `is-object`.

Motivations:
- There is no particular reasons to reject no-plain objects for config objects.
- Less dependencies
