### PR TITLE
fix: JSON.parse package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import {pathToFileURL} from 'node:url';
 import escapeStringRegexp from 'escape-string-regexp';
 import execa from 'execa';
 
-const pkg = fs.readFileSync(new URL('package.json', import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(new URL('package.json', import.meta.url)));
 const help = `See https://github.com/avajs/typescript/blob/v${pkg.version}/README.md`;
 
 function isPlainObject(x) {


### PR DESCRIPTION
`readFileSync` returns a Buffer. JSON.parse fixes this

![image](https://user-images.githubusercontent.com/15673111/140598543-c9086516-bbfc-4bec-b4ee-a0c932842e58.png)
