### PR TITLE
Add support for Node 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [^14.19, ^16.15, ^18, ^20]
+        node-version: [^14.19, ^16.15, ^18, ^20, ^21]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.0",
   "description": "TypeScript provider for AVA",
   "engines": {
-    "node": "^14.19 || ^16.15 || ^18 || ^20"
+    "node": "^14.19 || ^16.15 || ^18 || ^20 || ^21"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Currently the latest release of Node is not include in the `engines`  field of this package.

This PR adds Node 21 to this field and to the `node-version` in the matrix of the GitHub Actions CI.