### PR TITLE
Add support for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [^18.18, ^20.8, ^21, ^22]
+        node-version: [^18.18, ^20.8, ^21, ^22, ^24]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "description": "TypeScript provider for AVA",
   "engines": {
-    "node": "^18.18 || ^20.8 || ^21 || ^22"
+    "node": "^18.18 || ^20.8 || ^21 || ^22 || >=24"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Currently, npm will install `@ava/typescript@4` when running `npm i @ava/typescript` with Node.js 24.

This will confuse users who want to use the latest `ava` with TypeScript.

I've added Node.js 24 to the `engines` field and workflow matrix list to fix this issue.