### PR TITLE
Add node.js v23 to compatible engines list in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.0",
   "description": "TypeScript provider for AVA",
   "engines": {
-    "node": "^20.8 || ^22 || >=24"
+    "node": "^20.8 || ^22 || ^23 | >=24"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Hi all,
Is there a reason why Node.js v23 is currently not supported (package.json)?
Thanks